### PR TITLE
Add support for multiple numpy versions and pin for build and run phases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,13 +9,22 @@ environment:
     secure: ipv/06DzgA7pzz2CIAtbPxZSsphDtF+JFyoWRnXkn3O8j7oRe3rzqj3LOoq2DZp4
 
   matrix:
-    - CONFIG: win_python2.7
+    - CONFIG: win_numpy1.13python2.7
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_python3.5
+    - CONFIG: win_numpy1.13python3.5
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_python3.6
+    - CONFIG: win_numpy1.13python3.6
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_numpy1.14python2.7
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_numpy1.14python3.5
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
+
+    - CONFIG: win_numpy1.14python3.6
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.ci_support/linux_numpy1.13python2.7.yaml
+++ b/.ci_support/linux_numpy1.13python2.7.yaml
@@ -1,6 +1,8 @@
+numpy:
+- '1.13'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '2.7'

--- a/.ci_support/linux_numpy1.13python3.5.yaml
+++ b/.ci_support/linux_numpy1.13python3.5.yaml
@@ -1,0 +1,8 @@
+numpy:
+- '1.13'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.5'

--- a/.ci_support/linux_numpy1.13python3.6.yaml
+++ b/.ci_support/linux_numpy1.13python3.6.yaml
@@ -1,6 +1,8 @@
+numpy:
+- '1.13'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.5'
+- '3.6'

--- a/.ci_support/linux_numpy1.14python2.7.yaml
+++ b/.ci_support/linux_numpy1.14python2.7.yaml
@@ -1,3 +1,5 @@
+numpy:
+- '1.14'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_numpy1.14python3.5.yaml
+++ b/.ci_support/linux_numpy1.14python3.5.yaml
@@ -1,0 +1,8 @@
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.5'

--- a/.ci_support/linux_numpy1.14python3.6.yaml
+++ b/.ci_support/linux_numpy1.14python3.6.yaml
@@ -1,0 +1,8 @@
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/osx_numpy1.13python2.7.yaml
+++ b/.ci_support/osx_numpy1.13python2.7.yaml
@@ -4,6 +4,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+numpy:
+- '1.13'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_numpy1.13python3.5.yaml
+++ b/.ci_support/osx_numpy1.13python3.5.yaml
@@ -1,0 +1,14 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+numpy:
+- '1.13'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.5'

--- a/.ci_support/osx_numpy1.13python3.6.yaml
+++ b/.ci_support/osx_numpy1.13python3.6.yaml
@@ -1,0 +1,14 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+numpy:
+- '1.13'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/osx_numpy1.14python2.7.yaml
+++ b/.ci_support/osx_numpy1.14python2.7.yaml
@@ -4,9 +4,11 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+numpy:
+- '1.14'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '2.7'

--- a/.ci_support/osx_numpy1.14python3.5.yaml
+++ b/.ci_support/osx_numpy1.14python3.5.yaml
@@ -4,6 +4,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+numpy:
+- '1.14'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_numpy1.14python3.6.yaml
+++ b/.ci_support/osx_numpy1.14python3.6.yaml
@@ -1,0 +1,14 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.ci_support/win_numpy1.13python2.7.yaml
+++ b/.ci_support/win_numpy1.13python2.7.yaml
@@ -1,6 +1,8 @@
+numpy:
+- '1.13'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '2.7'

--- a/.ci_support/win_numpy1.13python3.5.yaml
+++ b/.ci_support/win_numpy1.13python3.5.yaml
@@ -1,0 +1,8 @@
+numpy:
+- '1.13'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.5'

--- a/.ci_support/win_numpy1.13python3.6.yaml
+++ b/.ci_support/win_numpy1.13python3.6.yaml
@@ -1,6 +1,8 @@
+numpy:
+- '1.13'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.5'
+- '3.6'

--- a/.ci_support/win_numpy1.14python2.7.yaml
+++ b/.ci_support/win_numpy1.14python2.7.yaml
@@ -1,3 +1,5 @@
+numpy:
+- '1.14'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_numpy1.14python3.5.yaml
+++ b/.ci_support/win_numpy1.14python3.5.yaml
@@ -1,0 +1,8 @@
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.5'

--- a/.ci_support/win_numpy1.14python3.6.yaml
+++ b/.ci_support/win_numpy1.14python3.6.yaml
@@ -1,0 +1,8 @@
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2
 
 jobs:
-  build_linux_python2.7:
+  build_linux_numpy1.13python2.7:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python2.7"
+      - CONFIG: "linux_numpy1.13python2.7"
     steps:
       - checkout
       - run:
@@ -18,11 +18,11 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_linux_python3.5:
+  build_linux_numpy1.13python3.5:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python3.5"
+      - CONFIG: "linux_numpy1.13python3.5"
     steps:
       - checkout
       - run:
@@ -35,11 +35,62 @@ jobs:
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./.circleci/run_docker_build.sh
-  build_linux_python3.6:
+  build_linux_numpy1.13python3.6:
     working_directory: ~/test
     machine: true
     environment:
-      - CONFIG: "linux_python3.6"
+      - CONFIG: "linux_numpy1.13python3.6"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_numpy1.14python2.7:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_numpy1.14python2.7"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_numpy1.14python3.5:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_numpy1.14python3.5"
+    steps:
+      - checkout
+      - run:
+          name: Fast finish outdated PRs and merge PRs
+          command: |
+            ./.circleci/fast_finish_ci_pr_build.sh
+            ./.circleci/checkout_merge_commit.sh
+      - run:
+          command: docker pull condaforge/linux-anvil
+      - run:
+          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
+          command: ./.circleci/run_docker_build.sh
+  build_linux_numpy1.14python3.6:
+    working_directory: ~/test
+    machine: true
+    environment:
+      - CONFIG: "linux_numpy1.14python3.6"
     steps:
       - checkout
       - run:
@@ -57,6 +108,9 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_linux_python2.7
-      - build_linux_python3.5
-      - build_linux_python3.6
+      - build_linux_numpy1.13python2.7
+      - build_linux_numpy1.13python3.5
+      - build_linux_numpy1.13python3.6
+      - build_linux_numpy1.14python2.7
+      - build_linux_numpy1.14python3.5
+      - build_linux_numpy1.14python3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ osx_image: xcode6.4
 
 env:
   matrix:
-    - CONFIG=osx_python2.7
-    - CONFIG=osx_python3.5
-    - CONFIG=osx_python3.6
+    - CONFIG=osx_numpy1.13python2.7
+    - CONFIG=osx_numpy1.13python3.5
+    - CONFIG=osx_numpy1.13python3.6
+    - CONFIG=osx_numpy1.14python2.7
+    - CONFIG=osx_numpy1.14python3.5
+    - CONFIG=osx_numpy1.14python3.6
 
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,6 @@
+numpy:
+  # Numpy version 1.13 introduced an important bug fix that lets quaternion
+  # work correctly.  Moreover, the C-API tends to change, so each version after
+  # 1.13 with a different C-API version should be supported.
+  - 1.13
+  - 1.14

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: package_version={{ version }} python -m pip install --no-deps --ignore-installed .           # [not win]
   script: set "package_version={{ version }}" && python -m pip install --no-deps --ignore-installed .  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,11 +21,11 @@ requirements:
   build:
     - python
     - pip
-    - numpy >=1.13
+    - numpy {{ numpy }}
     - toolchain
   run:
     - python
-    - numpy >=1.13
+    - numpy {{ numpy }}
 
 test:
   imports:


### PR DESCRIPTION
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)

Adds a `conda_build_config.yaml` file listing numpy versions 1.13 and 1.14 as separate builds, and puts the corresponding version numbers in the `build` and `run` requirements of `meta.yaml`.

This allows numpy 1.13 to be used.  Previously, even though this built against 1.14, users of 1.13 would be able to install without any trouble, but as soon as they tried to use the package numpy would give them an error saying that the API versions didn't match.  Closes moble/quaternion#82

@conda-forge-admin, please rerender
